### PR TITLE
Add hostname display to network status popup and update styles

### DIFF
--- a/assets/index.html
+++ b/assets/index.html
@@ -1,27 +1,30 @@
 <!DOCTYPE html>
 <html lang=en>
 <head>
-<link href=assets/style.css rel=stylesheet type=text/css />
-<script src=assets/index.js></script>
+	<link href=assets/style.css rel=stylesheet type=text/css />
+	<script src=assets/index.js></script>
 </head>
 <body>
 
-	<img id=logo />
-	<div id=text></div>
-	<div id=info></div>
+<img id=logo />
+<div id=text></div>
+<div id=info></div>
 
-	<div class="network-button" id="network-button"></div>
+<div class="network-button" id="network-button"></div>
 
-	<div class="network-popup" id="network-popup">
-	  <div class="network-popup-content">
-	    <div>Netzwerk-Informationen</div>
-	    <div id="network-status">Verbindungsstatus: <span id="connection-status">Wird geladen...</span></div>
-	    <div id="network-interfaces">
-	      <h4>Netzwerkschnittstellen</h4>
-	      <div id="interfaces-list">Wird geladen...</div>
-	    </div>
-	    <button id="close-popup">Schließen</button>
-	  </div>
+<div class="network-popup" id="network-popup">
+	<div class="network-popup-content">
+		<div>Netzwerk-Informationen</div>
+		<div id="network-status">
+			<div>Verbindungsstatus: <span id="connection-status">Wird geladen...</span></div>
+			<div class="hostname-container">Hostname: <span id="hostname">-</span></div>
+		</div>
+		<div id="network-interfaces">
+			<h4>Netzwerkschnittstellen</h4>
+			<div id="interfaces-list">Wird geladen...</div>
+		</div>
+		<button id="close-popup">Schließen</button>
 	</div>
+</div>
 </body>
 </html>

--- a/assets/index.js
+++ b/assets/index.js
@@ -4,6 +4,7 @@ var calendar = [];
 var network_status = {
     interfaces: [],
     connected: false,
+    hostename: ""
 };
 
 /**
@@ -176,6 +177,15 @@ document.addEventListener('DOMContentLoaded', function () {
         const connectionStatus = document.getElementById('connection-status');
         connectionStatus.textContent = data.connected ? 'Verbunden' : 'Nicht verbunden';
         connectionStatus.className = data.connected ? 'connected' : 'disconnected';
+
+        // Hostname anzeigen
+        const hostnameElement = document.getElementById('hostname');
+        if (data.hostname) {
+            hostnameElement.textContent = data.hostname;
+            hostnameElement.parentElement.style.display = 'block';
+        } else {
+            hostnameElement.parentElement.style.display = 'none';
+        }
 
         // Netzwerkschnittstellen anzeigen
         const interfacesList = document.getElementById('interfaces-list');

--- a/assets/style.css
+++ b/assets/style.css
@@ -106,3 +106,13 @@ body {
 .interface-name {
   font-weight: bold;
 }
+
+.hostname-container {
+  margin-top: 8px;
+  padding: 4px 0;
+  font-size: 14px;
+}
+
+#hostname {
+  font-weight: bold;
+}

--- a/main.go
+++ b/main.go
@@ -94,6 +94,7 @@ type DisplayConfig struct {
 type NetworkStatus struct {
 	Interfaces []NetInterface `json:"interfaces"`
 	Connected  bool           `json:"connected"`
+	Hostname   string         `json:"hostname"`
 }
 type NetInterface struct {
 	Name   string   `json:"name"`
@@ -379,6 +380,10 @@ func setupRouter() *gin.Engine {
 			net_status.Connected = false
 		} else {
 			net_status.Connected = true
+		}
+		net_status.Hostname, err = os.Hostname()
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, nil)
 		}
 		c.JSON(http.StatusOK, net_status)
 	})

--- a/opencast-ca-display.yml
+++ b/opencast-ca-display.yml
@@ -7,7 +7,7 @@ opencast:
   password: opencast
 
   # Capture agent to show the status for
-  agent: test
+  agent: pyca@pyca-test.novalocal
 
 # Display configuration
 # Each state configuration contains four fields:


### PR DESCRIPTION
This pull request includes changes to display the hostname in the network status section of the application. The changes span multiple files, including HTML, JavaScript, CSS, Go, and a YAML configuration file.

### Enhancements to Network Status Display:

* [`assets/index.html`](diffhunk://#diff-8f44a03e933b56fda430003ddb8ff6653e64dac7e2f9bb7b5473e233807ef868L18-R21): Added a new div to display the hostname in the network status section.
* [`assets/index.js`](diffhunk://#diff-8d8f50ef7eebc27b0f9094ea877c56f1163ab3da5fcb980eb4cd640d3d566d75R7): Updated the network status object to include the hostname and added logic to display the hostname if available. [[1]](diffhunk://#diff-8d8f50ef7eebc27b0f9094ea877c56f1163ab3da5fcb980eb4cd640d3d566d75R7) [[2]](diffhunk://#diff-8d8f50ef7eebc27b0f9094ea877c56f1163ab3da5fcb980eb4cd640d3d566d75R181-R189)
* [`assets/style.css`](diffhunk://#diff-7acf28a188f1ab160e1833357fbab4a051e92a981a2196ee2700aa4ec35e14e8R109-R118): Added styling for the hostname container and the hostname element.

### Backend Support for Hostname:

* [`main.go`](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261R97): Modified the `NetworkStatus` struct to include the hostname and updated the router setup to retrieve and include the hostname in the network status response. [[1]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261R97) [[2]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261R384-R387)

### Configuration Update:

* [`opencast-ca-display.yml`](diffhunk://#diff-9cbc6f3bc0d5f972ac30f0f85286b654c758fc166ed09654116a03a99cefeb93L10-R10): Updated the capture agent configuration to use a new agent identifier.